### PR TITLE
Add pull-up resistor control

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,15 @@ int readAllInputs();
 >the bit in the byte is set to 1, if the input is open the bit in the byte is set to 0.  256 will be
 >returned if an error has occured(generally due to lack of communciation with controller).
 
+```cpp
+byte setPullUp(byte pullup);
+```
+>This method accepts one byte. Valid byte arguments 0x00 to 0xFC. A call to this method will set or remove the pull-up
+>resistors on the inputs. Setting the bit corresponding to the MCP23008 input pin will internally pull the pin high
+>through a 100Kohm resistor. By default the pull-up resistors are all enabled. Bit 7-0 corresponds to PU7:PU0
+>excluding bits 0 and 1 as they are the relay driver pins.
+>Example: default setting byte is 0XFC, to turn off the pull-up resistor for input 1 the byte value would be
+>0xF8 (remeber that 0 and 1 are for relay control).
 
 ###Public accessible variables
 ```cpp

--- a/firmware/NCD2Relay.h
+++ b/firmware/NCD2Relay.h
@@ -28,6 +28,8 @@ public:
     int readInputStatus(int input);
     //Read status of all inputs
     int readAllInputs();
+    //Set input pull-up resistors on or off
+    void setPullUp(byte pullup);
 
     //User Accessible Variables
     //Whether or not the controller is ready to accept commands


### PR DESCRIPTION
Adding this functionality to the official firmware will expose the input pin pull-up resistor control to all users. It will make my life a lot easier too.
I'll be more than happy to do this for the other relay controllers as well.

Thanks for taking a look, Glenn.