### PR TITLE
Set init

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ NCD2Relay relayController;
 
 void setup() {
     Serial.begin(115200);
-    relayController.setAddress(0,0,0);
+    relayController.setInit(0,0,0);
 }
 
 void loop() {
@@ -83,14 +83,19 @@ void loop() {
 
 ###Public accessible methods
 ```cpp
-void setAddress(int a0, int a1, int a2);
+void setInit(int a0, int a1, int a2, byte direction = 0xFC, byte pullup = 0xFC);
 ```
 >Must be called first before using the object.  This method should also be called any time communication with
->the controller is lost or broken to recover communication  This method accepts two int arguments.  This
->tells the Library what address to direct commands to.  a0 and a1 ints are representations of the two
->jumpers on the 4 channel relay controller which are labeled on the board A0, A1, and A2.  If the jumper is
->installed then that int in this call should be set to 1.  If it is not installed then the int should be set to
-So if I have A0, A1, and A2 installed I would call ```relayController.setAddress(1, 1, 1).```
+>the controller is lost or broken to recover communication  This method accepts three int arguments and optionally
+>two byte arguments.  int a0, int a1 and int a2 tell the Library what address to direct commands to.  a0, a1 and a2 
+>ints are representations of the three jumpers on the 2 channel relay controller which are labeled on the board A0, 
+>A1, and A2.  If the jumper is installed then that int in this call should be set to 1.  If it is not installed then
+>the int should be set to 0.
+>So if I have A0, A1, and A2 installed I would call ```relayController.setAddress(1, 1, 1).```
+>The direction and pullup arguments are optional and default to Input on GP2 through GP7 with pull-up resistors
+>enabled. direction can be called without pullup and will enable any inputs pull-up resistor. pullup cannot be called
+>without first calling direciton.
+>direction and pullup are set bitwise with 
 
 
 ```cpp

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The intention of this library is to make use of the NCD 2 channel relay controll
 ###Developer information
 NCD has been designing and manufacturing computer control products since 1995.  We have specialized in hardware design and manufacturing of Relay controllers for 20 years.  We pride ourselves as being the industry leader of computer control relay products.  Our products are proven reliable and we are very excited to support Particle.  For more information on NCD please visit www.controlanything.com
 
-###Requirements
+### Requirements
 - NCD 2 Channel Particle Core/Photon Compatible Relay board
 - Particle Core/Photon module
 - Knowledge base for developing and programming with Particle Core/Photon modules.
@@ -91,13 +91,17 @@ void setInit(int a0, int a1, int a2, byte direction = 0xFC, byte pullup = 0xFC);
 >ints are representations of the three jumpers on the 2 channel relay controller which are labeled on the board A0, 
 >A1, and A2.  If the jumper is installed then that int in this call should be set to 1.  If it is not installed then
 >the int should be set to 0.
-
->So if I have A0, A1, and A2 installed I would call ```relayController.setAddress(1, 1, 1).```
-
->The direction and pullup arguments are optional and default to Input on GP2 through GP7 with pull-up resistors
->enabled. direction can be called without pullup and will enable any inputs pull-up resistor. pullup cannot be called
->without first calling direciton.
->direction and pullup are set bitwise with 
+>
+>So if I have A0, A1, and A2 installed I would call ```relayController.setInit(1, 1, 1).```
+>
+>The direction and pullup arguments are optional and default to Input on GP2 through GP7 (input 1 through 6) with
+>pull-up resistors enabled. direction can be called without pullup and will enable all input pull-up resistors. 
+>pullup cannot be called without first calling direciton. direction and pullup are set bitwise with bit 2 representing
+>input/output 1 and bit 7 representing input/output 6.
+>
+>If I wanted to switch input 6 to an output with the pull-up resistor on I would call ```setInit(0,0,0,0x7C)```
+>
+>The same call but turning off the internal pull-up resistor is ```setInit(0,0,0,0x7C,0x7C)```
 
 
 ```cpp

--- a/README.md
+++ b/README.md
@@ -174,6 +174,15 @@ int readAllInputs();
 >the bit in the byte is set to 1, if the input is open the bit in the byte is set to 0.  256 will be
 >returned if an error has occured(generally due to lack of communciation with controller).
 
+```cpp
+byte setPullUp(byte pullup);
+```
+>This method accepts one byte. Valid byte arguments 0x00 to 0xFC. A call to this method will set or remove the pull-up
+>resistors on the inputs. Setting the bit corresponding to the MCP23008 input pin will internally pull the pin high
+>through a 100Kohm resistor. By default the pull-up resistors are all enabled. Bit 7-0 corresponds to PU7:PU0
+>excluding bits 0 and 1 as they are the relay driver pins.
+>Example: default setting byte is 0XFC, to turn off the pull-up resistor for input 1 the byte value would be
+>0xF8 (remeber that 0 and 1 are for relay control).
 
 ###Public accessible variables
 ```cpp

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ void setInit(int a0, int a1, int a2, byte direction = 0xFC, byte pullup = 0xFC);
 >pullup cannot be called without first calling direciton. direction and pullup are set bitwise with bit 2 representing
 >input/output 1 and bit 7 representing input/output 6.
 >
->If I wanted to switch input 6 to an output with the pull-up resistor on I would call ```setInit(0,0,0,0x7C)```
+>If I wanted to switch Input 6 to an output I would call ```setInit(0,0,0,0x7C)```
 >
->The same call but turning off the internal pull-up resistor is ```setInit(0,0,0,0x7C,0x7C)```
+>If I wanted to turn off the pull-up resistor on Input 1 I would call ```setInit(0,0,0,0xFC,0xF8)```
 
 
 ```cpp

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ void loop() {
 }
 ```
 
-###Public accessible methods
+### Public accessible methods
 ```cpp
 void setInit(int a0, int a1, int a2, byte direction = 0xFC, byte pullup = 0xFC);
 ```
@@ -91,7 +91,9 @@ void setInit(int a0, int a1, int a2, byte direction = 0xFC, byte pullup = 0xFC);
 >ints are representations of the three jumpers on the 2 channel relay controller which are labeled on the board A0, 
 >A1, and A2.  If the jumper is installed then that int in this call should be set to 1.  If it is not installed then
 >the int should be set to 0.
+
 >So if I have A0, A1, and A2 installed I would call ```relayController.setAddress(1, 1, 1).```
+
 >The direction and pullup arguments are optional and default to Input on GP2 through GP7 with pull-up resistors
 >enabled. direction can be called without pullup and will enable any inputs pull-up resistor. pullup cannot be called
 >without first calling direciton.

--- a/firmware/NCD2Relay.cpp
+++ b/firmware/NCD2Relay.cpp
@@ -9,7 +9,8 @@ NCD2Relay::NCD2Relay(){
 }
 
 //Retry added
-void NCD2Relay::setAddress(int a0, int a1, int a2){
+void NCD2Relay::setInit(int a0, int a1, int a2, byte direction, byte pullup){
+    // Set address
     address = 0x20;
     if(a0 == 1){
         address = address | 1;
@@ -20,20 +21,27 @@ void NCD2Relay::setAddress(int a0, int a1, int a2){
     if(a2 == 1){
         address = address | 4;
     }
+    
+    // Set GPIO direction
+    byte directionMasked = (direction & 0xFC);  // Mask out the relay control pins
+    // Set pull-up resistors
+    byte pullupMasked = (pullup & direction);   // Only set pullup on/off for inout pins
+    
     //Start I2C port
     Wire.begin();
     //Open connection to specified address
     retryAddress1:
     Wire.beginTransmission(address);
-    //Set all channels to outputs
+    //Set channels 0 and 1 to outputs
     Wire.write(0x00);
-    Wire.write(0xFC);
+    Wire.write(directionMasked);
     //Determine if device is present at that address
     byte status = Wire.endTransmission();
 
     Wire.beginTransmission(address);
+    // turn off pull-up resistors
     Wire.write(0x06);
-    Wire.write(0xFC);
+    Wire.write(pullupMasked);
     status = Wire.endTransmission();
     if(status != 0){
         if(retrys < 3){
@@ -450,17 +458,124 @@ int NCD2Relay::readAllInputs(){
     return shifted;
 }
 
-void NCD2Relay::setPullUp(byte pullup){
-    // twoRelayMask = 0x03;    // becuase this is the two relay board don't touch GPIO 1 and 2
-    if((pullup & twoRelayMask) > 0x00){
-        skippedPullup = 1;
+void NCD2Relay::setOutputOn(int output){
+    if(output > 6 || output < 1){
         return;
     }
+    byte bankValue = bankOneStatus;
+    byte registerAddress = 0x0A;
+    switch(output){
+        case 1:
+            bankValue = bankValue | 4;
+            break;
+        case 2:
+            bankValue = bankValue | 8;
+            break;
+        case 3:
+            bankValue = bankValue | 16;
+            break;
+        case 4:
+            bankValue = bankValue | 32;
+            break;
+        case 5:
+            bankValue = bankValue | 64;
+            break;
+        case 6:
+            bankValue = bankValue | 128;
+            break;
+    }
+    turnOutputOnRetry:
+    Wire.beginTransmission(address);
+    Wire.write(registerAddress);
+    Wire.write(bankValue);
+    byte status = Wire.endTransmission();
+    if(status != 0){
+        if(retrys < 3){
+    #ifdef LOGGING
+            Serial.println("Retry Turn On Output command");
+    #endif
+            retrys++;
+            goto turnOutputOnRetry;
+        }else{
+    #ifdef LOGGING
+        Serial.println("Turn on Relay Failed");
+    #endif
+        initialized = false;
+        retrys = 0;
+        }
+    }else{
+        initialized = true;
+        retrys = 0;
+        readStatus();
+    }
+    
+}
+
+void NCD2Relay::setOutputOff(int output){
+    if(output > 6 || output < 1){
+        return;
+    }
+    byte bankValue = bankOneStatus;
+    byte registerAddress = 0x0A;
+    switch(output){
+        case 1:
+            bankValue = bankValue | -4;
+            break;
+        case 2:
+            bankValue = bankValue | -8;
+            break;
+        case 3:
+            bankValue = bankValue | -16;
+            break;
+        case 4:
+            bankValue = bankValue | -32;
+            break;
+        case 5:
+            bankValue = bankValue | -64;
+            break;
+        case 6:
+            bankValue = bankValue | -128;
+            break;
+    }
+    turnOutputOffRetry:
+    Wire.beginTransmission(address);
+    Wire.write(registerAddress);
+    Wire.write(bankValue);
+    byte status = Wire.endTransmission();
+    if(status != 0){
+        if(retrys < 3){
+    #ifdef LOGGING
+            Serial.println("Retry Turn Off Output command");
+    #endif
+            retrys++;
+            goto turnOutputOffRetry;
+        }else{
+    #ifdef LOGGING
+        Serial.println("Turn Off Relay Failed");
+    #endif
+        initialized = false;
+        retrys = 0;
+        }
+    }else{
+        initialized = true;
+        retrys = 0;
+        readStatus();
+    }
+    
+}
+
+/* void NCD2Relay::setPullUp(byte pullup){
+    // twoRelayMask = 0x03;    // becuase this is the two relay board don't touch GPIO 1 and 2
+//    if((pullup & twoRelayMask) > 0x00){
+//        return;
+//    }
+    byte pullupMasked = (pullup & 0xFC); // mask out the relay outputs
+    
     byte registerAddress = 0x06;
     setPullUpRetry:
     Wire.beginTransmission(address);
     Wire.write(registerAddress);
-    Wire.write(pullup);
+    Wire.write(pullupMasked);
     byte status = Wire.endTransmission();
     if(status !=0){
         if(retrys < 3){
@@ -483,3 +598,4 @@ void NCD2Relay::setPullUp(byte pullup){
         readStatus();
     }
 }
+*/

--- a/firmware/NCD2Relay.cpp
+++ b/firmware/NCD2Relay.cpp
@@ -458,7 +458,7 @@ int NCD2Relay::readAllInputs(){
     return shifted;
 }
 
-void NCD2Relay::setOutputOn(int output){
+void NCD2Relay::setOutputHigh(int output){
     if(output > 6 || output < 1){
         return;
     }
@@ -484,7 +484,7 @@ void NCD2Relay::setOutputOn(int output){
             bankValue = bankValue | 128;
             break;
     }
-    turnOutputOnRetry:
+    setOutputHighRetry:
     Wire.beginTransmission(address);
     Wire.write(registerAddress);
     Wire.write(bankValue);
@@ -495,7 +495,7 @@ void NCD2Relay::setOutputOn(int output){
             Serial.println("Retry Turn On Output command");
     #endif
             retrys++;
-            goto turnOutputOnRetry;
+            goto setOutputHighRetry;
         }else{
     #ifdef LOGGING
         Serial.println("Turn on Relay Failed");
@@ -511,7 +511,7 @@ void NCD2Relay::setOutputOn(int output){
     
 }
 
-void NCD2Relay::setOutputOff(int output){
+void NCD2Relay::setOutputLow(int output){
     if(output > 6 || output < 1){
         return;
     }
@@ -519,25 +519,25 @@ void NCD2Relay::setOutputOff(int output){
     byte registerAddress = 0x0A;
     switch(output){
         case 1:
-            bankValue = bankValue | -4;
+            bankValue = bankValue & ~4;
             break;
         case 2:
-            bankValue = bankValue | -8;
+            bankValue = bankValue & ~8;
             break;
         case 3:
-            bankValue = bankValue | -16;
+            bankValue = bankValue & ~16;
             break;
         case 4:
-            bankValue = bankValue | -32;
+            bankValue = bankValue & ~32;
             break;
         case 5:
-            bankValue = bankValue | -64;
+            bankValue = bankValue & ~64;
             break;
         case 6:
-            bankValue = bankValue | -128;
+            bankValue = bankValue & ~128;
             break;
     }
-    turnOutputOffRetry:
+    setOutputLowRetry:
     Wire.beginTransmission(address);
     Wire.write(registerAddress);
     Wire.write(bankValue);
@@ -548,7 +548,7 @@ void NCD2Relay::setOutputOff(int output){
             Serial.println("Retry Turn Off Output command");
     #endif
             retrys++;
-            goto turnOutputOffRetry;
+            goto setOutputLowRetry;
         }else{
     #ifdef LOGGING
         Serial.println("Turn Off Relay Failed");
@@ -563,39 +563,3 @@ void NCD2Relay::setOutputOff(int output){
     }
     
 }
-
-/* void NCD2Relay::setPullUp(byte pullup){
-    // twoRelayMask = 0x03;    // becuase this is the two relay board don't touch GPIO 1 and 2
-//    if((pullup & twoRelayMask) > 0x00){
-//        return;
-//    }
-    byte pullupMasked = (pullup & 0xFC); // mask out the relay outputs
-    
-    byte registerAddress = 0x06;
-    setPullUpRetry:
-    Wire.beginTransmission(address);
-    Wire.write(registerAddress);
-    Wire.write(pullupMasked);
-    byte status = Wire.endTransmission();
-    if(status !=0){
-        if(retrys < 3){
-    #ifdef LOGGING
-            Serial.println("Retry set pull-up");
-    #endif
-            retrys++;
-            goto setPullUpRetry;
-        }else{
-    #ifdef LOGGING
-        Serial.println("Set Pull Up failed");
-    #endif
-            initialized = false;
-            retrys = 0;
-        }
-        
-    }else{
-        initialized = true;
-        retrys = 0;
-        readStatus();
-    }
-}
-*/

--- a/firmware/NCD2Relay.h
+++ b/firmware/NCD2Relay.h
@@ -6,8 +6,10 @@ class NCD2Relay{
 public:
     //Constructor
     NCD2Relay(void);
-    //Set Address.  Indicate status of jumpers on board.  Send 0 for not installed, send 1 for installed
-    void setAddress(int a0, int a1, int a2);
+    //Set Init.  a0 through a1 Indicate status of jumpers on board.  Send 0 for not installed, send 1 for installed.
+    //           Optional: direction set GPIO pin as input or output bitwise, 1 input, 0 output
+    //           Optional: pullup set GPIO internal pull-up resistors on or off bitwise, 1 on, 0 off.
+    void setInit(int a0, int a1, int a2, byte direction = 0xFC, byte pullup = 0xFC);
     //Turn on Relay
     void turnOnRelay(int relay);
     //Turn off Relay
@@ -28,13 +30,17 @@ public:
     int readInputStatus(int input);
     //Read status of all inputs
     int readAllInputs();
-    //Set input pull-up resistors on or off
-    void setPullUp(byte pullup);
+    // Turn on output if enabled
+    void setOutputOn(int output);
+    // Turn off output if enabled
+    void setOutputOff(int output);
+    // Set input pull-up resistors on or off
+    //void setPullUp(byte pullup);
 
     //User Accessible Variables
     //Whether or not the controller is ready to accept commands
     bool initialized;
-
+    
 private:
     //internal use method for refreshing bank status variables
     void readStatus();

--- a/firmware/NCD2Relay.h
+++ b/firmware/NCD2Relay.h
@@ -28,6 +28,8 @@ public:
     int readInputStatus(int input);
     //Read status of all inputs
     int readAllInputs();
+    //Set input pull-up resistors on or off
+    void setPullUp(byte pullup);
 
     //User Accessible Variables
     //Whether or not the controller is ready to accept commands

--- a/firmware/NCD2Relay.h
+++ b/firmware/NCD2Relay.h
@@ -9,6 +9,7 @@ public:
     //Set Init.  a0 through a1 Indicate status of jumpers on board.  Send 0 for not installed, send 1 for installed.
     //           Optional: direction set GPIO pin as input or output bitwise, 1 input, 0 output
     //           Optional: pullup set GPIO internal pull-up resistors on or off bitwise, 1 on, 0 off.
+    //           Default address: 000; direction: all inputs; pullup: all enabled.
     void setInit(int a0, int a1, int a2, byte direction = 0xFC, byte pullup = 0xFC);
     //Turn on Relay
     void turnOnRelay(int relay);
@@ -31,9 +32,9 @@ public:
     //Read status of all inputs
     int readAllInputs();
     // Turn on output if enabled
-    void setOutputOn(int output);
+    void setOutputHigh(int output);
     // Turn off output if enabled
-    void setOutputOff(int output);
+    void setOutputLow(int output);
     // Set input pull-up resistors on or off
     //void setPullUp(byte pullup);
 


### PR DESCRIPTION
Here is the library changing setAddress to setInit. The arguments for direction and pullup are optional and can be left out when setting just the address. This library still defaults the remaining GPIO pins to Inputs with the pull-up resistors enabled.

I updated README.md as well.

Let me know what you think and if you would like to change anything.

Glenn